### PR TITLE
Update incorrect timeout after precommit

### DIFF
--- a/pio-mainnet-1/config.toml
+++ b/pio-mainnet-1/config.toml
@@ -335,7 +335,7 @@ timeout_precommit_delta = "500ms"
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
-timeout_commit = "5s"
+timeout_commit = "4s"
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus
 # When non-zero, the node will panic upon restart


### PR DESCRIPTION
Timeout must be less than 5s to maintain a 5 second block cut time