### PR TITLE
Update config.toml

### DIFF
--- a/pio-mainnet-1/config.toml
+++ b/pio-mainnet-1/config.toml
@@ -332,10 +332,14 @@ timeout_prevote_delta = "500ms"
 timeout_precommit = "1s"
 # How much the timeout_precommit increases with each round
 timeout_precommit_delta = "500ms"
+
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
-timeout_commit = "5s"
+# !! NOTE: Provenance Blockchain targets a 5.0s time per block.  As part of maintaining this target during each
+# software upgrade it is recommended that this value be adjusted slightly up or down as required to achieve 
+# the targeted average block times. !!
+timeout_commit = "4300ms"
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus
 # When non-zero, the node will panic upon restart


### PR DESCRIPTION
Updates the commit timeout default value from 5s to 4300ms and adds a notice of how this value is expected to be adjusted over time to maintain the target 5s average block time for the network.