### PR TITLE
Remove persistent peers from Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,4 @@ The following list provides the software versions in use and the blockheight whe
 The first public mainnet using the 0.40 SDK base Provenance Blockchain is focused on streamlining the process for building the public network configuration.
 
 - **Explorer** - [explorer.provenance.io](https://explorer.provenance.io)
-- **Persistant Peers** - 9e9c66cc7e22ef2be11a02a944c4d150ed742f52@rpc-0.provenance.io:26656, 738b4657416504d79af3e9bf45f4a2a813d2fbd6@rpc-1.provenance.io:26656, eea0ff9ac8c228d7827100fcb00cb9b1f5274db6@rpc-2.provenance.io:26656, 87592d58ecd6a56bfb4e6fbb96111ec9a6918dc9@rpc-3.provenance.io:26656
 - **Seed Nodes** - 4bd2fb0ae5a123f1db325960836004f980ee09b4@seed-0.provenance.io:26656, 048b991204d7aac7209229cbe457f622eed96e5d@seed-1.provenance.io:26656


### PR DESCRIPTION
Remove persistent peers because the referenced nodes will be overloaded and prevent a node from properly running.