### PR TITLE
Removed persistent peers in favor of just seed nodes

### DIFF
--- a/pio-mainnet-1/config.toml
+++ b/pio-mainnet-1/config.toml
@@ -184,7 +184,7 @@ external_address = ""
 seeds = "4bd2fb0ae5a123f1db325960836004f980ee09b4@seed-0.provenance.io:26656,048b991204d7aac7209229cbe457f622eed96e5d@seed-1.provenance.io:26656"
 
 # Comma separated list of nodes to keep persistent connections to
-persistent_peers = "9e9c66cc7e22ef2be11a02a944c4d150ed742f52@rpc-0.provenance.io:26656,738b4657416504d79af3e9bf45f4a2a813d2fbd6@rpc-1.provenance.io:26656,eea0ff9ac8c228d7827100fcb00cb9b1f5274db6@rpc-2.provenance.io:26656,87592d58ecd6a56bfb4e6fbb96111ec9a6918dc9@rpc-3.provenance.io:26656"
+persistent_peers = ""
 
 # UPNP port forwarding
 upnp = false


### PR DESCRIPTION
We are now relying on seed nodes and the community network for peering connections, no connections should be made specifically to these nodes going forward