### PR TITLE
Update to bring in line with testnet style build, deploy, and runtime.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,60 @@
+name: Build docker images
+on:
+  pull_request:
+
+  push:
+    branches:
+      - main
+    paths:
+      - "docker/node/**"
+      - "pio-testnet-1/**"
+      - "testnet-beta/**"
+
+  # Also run every Wednesday at 12:00am.
+  schedule:
+    - cron: '0 0 * * 3'
+
+  # Also enable manual runs for when too much inactivity has disabled the workflow.
+  workflow_dispatch:
+
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        net: ["pio-mainnet-1"]
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Publish archive nodes
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            CHAIN_ID=${{ matrix.net }}
+          platforms: linux/amd64
+          file: docker/node/archive/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: provenanceio/node:${{ matrix.net }}-archive
+      - name: Publish cosmovisor nodes
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            CHAIN_ID=${{ matrix.net }}
+          platforms: linux/amd64
+          file: docker/node/visor/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: provenanceio/node:${{ matrix.net }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Mainnet configurations for public [Provenance.io](https://provenance.io) network
 
 ### `pio-mainnet-1` Upgrades
 
-The following list provides the software versions in use and the blockheight when they were migrated to.
+The full upgrades list can be found at https://explorer.provenance.io/network/upgrades
 
 | Upgrage Name  | Software Version | Wasm Version  | Block Height         |
 |---------------|------------------|---------------|----------------------|

--- a/docker/node/archive/Dockerfile
+++ b/docker/node/archive/Dockerfile
@@ -1,5 +1,5 @@
 # Buildtime container
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 ARG CHAIN_ID
 ENV CHAIN_ID=$CHAIN_ID PIO_HOME=/home/provenance
 
@@ -8,8 +8,8 @@ RUN if [ -z "${CHAIN_ID}" ]; then echo "Build argument needs to be set and non-e
 
 ADD $CHAIN_ID/genesis-version.txt /$CHAIN_ID/genesis-version.txt
 
-RUN apt-get update && \
-    apt-get install -y ca-certificates unzip wget jq libleveldb-dev && \
+RUN apt update && \
+    apt install -y ca-certificates unzip wget jq libleveldb-dev && \
     ln -s /usr/lib/x86_64-linux-gnu/libleveldb.so.1d /usr/lib/x86_64-linux-gnu/libleveldb.so.1
 
 RUN GENESIS_VERSION="$(cat /$CHAIN_ID/genesis-version.txt)" && \

--- a/docker/node/visor/Dockerfile
+++ b/docker/node/visor/Dockerfile
@@ -19,7 +19,23 @@ RUN mkdir -p ${DAEMON_HOME}/cosmovisor/genesis/bin && \
     cp /usr/bin/provenanced /usr/lib/libwasmvm.so ${DAEMON_HOME}/cosmovisor/genesis/bin/ && \
     ln -s /home/provenance/cosmovisor/genesis /home/provenance/cosmovisor/current
 
+# Pull cosmovisor from the cosmovisor image layer.
 COPY --from=visor /usr/bin/cosmovisor /usr/bin/cosmovisor
 
+# Docker entrypoint slightly differs from node's.
+ADD docker/node/visor/docker-entrypoint.sh /docker-entrypoint.sh
+
+# Create the daemon user
+RUN useradd -ms /bin/bash -U provenance
+RUN chown -R provenance:provenance /home/provenance
+
+# Drop root privileges.
+USER provenance:provenance
+WORKDIR /home/provenance
+
+# Mount the application's home dir.
+VOLUME ["/home/provenance"]
+
+# Start the node.
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["sh", "-c", "/usr/bin/cosmovisor start $(cat /$CHAIN_ID/extra-args.txt)"]

--- a/docker/node/visor/docker-entrypoint.sh
+++ b/docker/node/visor/docker-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# No config dir yet, create it.
+if [ ! -d "${PIO_HOME}/config" ]; then
+  mkdir -p "${PIO_HOME}/config"
+fi
+
+# No data dir yet, create it.
+if [ ! -d "${PIO_HOME}/data" ]; then
+    mkdir "${PIO_HOME}/data"
+fi
+
+# No cosmovisor dir yet, create it.
+if [ ! -d "${DAEMON_HOME}/cosmovisor" ]; then
+  mkdir -p "${DAEMON_HOME}/cosmovisor/genesis/bin"
+  cp /usr/bin/provenanced /usr/lib/libwasmvm.so "${DAEMON_HOME}/cosmovisor/genesis/bin/"
+  ln -s "${DAEMON_HOME}/cosmovisor/genesis" "${DAEMON_HOME}/cosmovisor/current"
+fi
+
+# If custom genesis.json is not provided, use the default.
+if [ ! -f "${PIO_HOME}/config/genesis.json" ]; then
+  cp "/${CHAIN_ID}/genesis.json" "${PIO_HOME}/config/genesis.json"
+fi
+
+# If custom config.toml is not provided, use the default.
+if [ ! -f "${PIO_HOME}/config/config.toml" ]; then
+  cp "/${CHAIN_ID}/node-config.toml" "${PIO_HOME}/config/config.toml"
+fi
+
+# If custom app.toml is not provided, use the default.
+if [ ! -f "${PIO_HOME}/config/app.toml" ]; then
+  cp "/${CHAIN_ID}/node-app.toml" "${PIO_HOME}/config/app.toml"
+fi
+
+exec "$@"


### PR DESCRIPTION
* Add github action to build and publish to docker hub
* Point to explorer for upgrades in README
* Bring Dockerfile in line with testnet Dockerfile (also in line with what's actually in docker hub)