### PR TITLE
Scripts for syncing an archive node from genesis.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .history/
 .idea/
 chains/
+*-done
+archive-node/node/data
+archive-node/node/config
+archive-node/archive/*tar.gz
+archive-node/software/v*/

--- a/archive-node/archive/readme.md
+++ b/archive-node/archive/readme.md
@@ -1,0 +1,1 @@
+Backups of the blockchain data will be created in this folder.  Ensure there are many terabytes of storage available to hold all of these backups.  It may help to remove them during the process if they are not needed any longer.

--- a/archive-node/node/readme.md
+++ b/archive-node/node/readme.md
@@ -1,0 +1,1 @@
+The node folder is where the blockchain node data and configuration will be created when the [start.sh](../start.sh) script is executed.

--- a/archive-node/readme.md
+++ b/archive-node/readme.md
@@ -1,0 +1,7 @@
+# Archive Node
+
+Building an archive node from genesis involves upgrading through the various different versions of the protocol used since genesis.  It also requires a correct configuration of the node with appropriate versions of `cleveldb` and transistions to `goleveldb` at specific blockheights.  The scripts in this folder will properly run the versions with the required configuration changes at each height.  
+
+In addition these scripts will create the appropriate backups of the node data directory at each height several blocks before an upgrade.  This is an important (and often overlooked) part of synchronizing a node.  Many different people over the years have failed to do this and been forced to start over when an upgrade has failed.  This can result in many days worth of processing time being lost.
+
+The archive node scripts rely on software releases already existing in the appropriate version folders (i.e. `./software/v1.6.0/provenanced`) or it will attempt to checkout the appropriate tag and build the software for use.  The software build process requires a fair amount of setup in the local environment.  It is recommended that the software build process be verified before using these scripts (ideally checkout and build each version in the associated folders before attempting to use the archive node scripts).

--- a/archive-node/software/readme.md
+++ b/archive-node/software/readme.md
@@ -1,0 +1,1 @@
+This folder should contain subfolders named with the version number of the software starting with a `v` and containing the protocol binary.  For example `./software/v1.6.0/provenanced`.  A list of the required software versions can be found in the [upgrades.json](../upgrades.json) file.

--- a/archive-node/start.sh
+++ b/archive-node/start.sh
@@ -45,7 +45,7 @@ curl -s "https://raw.githubusercontent.com/provenance-io/mainnet/main/pio-mainne
 
 # 0            genesis          v1.0.1
 ./software/v1.0.1/provenanced --home="./node" start --halt-height=351990 --log_level=warn
-rm -rf ./data/wasm/wasm/cache
+rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/351990-1.0.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
 ./software/v1.0.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
 

--- a/archive-node/start.sh
+++ b/archive-node/start.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -ex
+
+# if we are already done here then don't run this file again since it is destructive.
+if [ -f "./v1.0.1-done" ]; then exit 0; fi
+
+# look for the proper software binary, if not found then build it.
+if [ ! -f "./software/v1.0.1/provenanced" ]; then
+
+    # Setup a source checkout
+    mkdir -p ./software/source # just in case
+    rm -rf ./software/source # clear out any existing checkout
+    git clone git@github.com:provenance-io/provenance.git ./software/source
+
+    pushd ./software/source
+    git checkout v1.0.1
+    make clean build
+    mkdir -p ../v1.0.1/
+    cp ./build/* ../v1.0.1
+    popd
+
+fi;
+
+# !!!!!!!!!!!!!!! Warning - Bad Times Ahead if you are not careful !!!!!!!!!!!!! 
+rm -rf ./node/* ./archive/*
+
+export PIO_P2P_SEEDS=$(curl -s https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/chain.json | jq -r '[foreach .peers.seeds[] as $item (""; "\($item.id)@\($item.address)")] | join(",")')
+
+# !!!!!!!!!!!!!! Initial Setup and Configuration
+mkdir -p ./node ./archive
+./software/v1.0.1/provenanced --home="./node" init pio-mainnet-1
+
+sed -i -r 's/pruning = "default"/pruning = "nothing"/' ./node/config/app.toml
+sed -i -r 's/minimum-gas-prices=\"0.025nhash\"/minimum-gas-prices=\"1905nhash\"/' ./node/config/app.toml
+sed -i -r "s/max_num_inbound_peers = 40/max_num_inbound_peers = 500/" ./node/config/config.toml
+sed -i -r "s/seeds = \"\"/seeds = \"$PIO_P2P_SEEDS\"/" ./node/config/config.toml
+sed -i -r "s/db_backend = \"goleveldb\"/db_backend = \"cleveldb\"/" ./node/config/config.toml
+
+curl -s "https://raw.githubusercontent.com/provenance-io/mainnet/main/pio-mainnet-1/genesis.json" > ./node/config/genesis.json
+
+./software/v1.0.1/provenanced --home="./node" unsafe-reset-all
+
+
+# !!!!!!!!!!!!! Node Sync Process !!!!!!!!!!!!!!!!!
+
+# 0            genesis          v1.0.1
+./software/v1.0.1/provenanced --home="./node" start --halt-height=351990 --log_level=warn
+rm -rf ./data/wasm/wasm/cache
+tar czf ./archive/351990-1.0.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
+./software/v1.0.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+
+touch ./v1.0.1-done

--- a/archive-node/start.sh
+++ b/archive-node/start.sh
@@ -47,6 +47,6 @@ curl -s "https://raw.githubusercontent.com/provenance-io/mainnet/main/pio-mainne
 ./software/v1.0.1/provenanced --home="./node" start --halt-height=351990 --log_level=warn
 rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/351990-1.0.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
-./software/v1.0.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+./software/v1.0.1/provenanced --home="./node" start --log_level=warn || true  # run until upgrade halts node, don't exit script on upgrade panic
 
 touch ./v1.0.1-done

--- a/archive-node/status.sh
+++ b/archive-node/status.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+get_latest_block_height() {
+  curl -s "http://localhost:26657/status" | jq -r '.result.sync_info.latest_block_height'
+}
+
+get_correct_current_upgrade() {
+  local block_height=$1
+  jq -r --argjson height "$block_height" '
+    .upgrades
+    | map(select(.height <= $height))
+    | sort_by(.height)
+    | reverse
+    | map(select(.height <= $height))
+    | .[0]
+  ' upgrades.json
+}
+
+get_next_upgrade() {
+  local block_height=$1
+  jq -r --argjson height "$block_height" '
+    .upgrades
+    | map(select(.height > $height))
+    | sort_by(.height)
+    | first
+  ' upgrades.json
+}
+
+start_time=$(date +"%Y-%m-%d %H:%M:%S")
+start_time_unix=$(date +%s)
+initial_height=$(get_latest_block_height)
+
+sleep 10
+
+end_time=$(date +"%Y-%m-%d %H:%M:%S")
+end_time_unix=$(date +%s)
+final_height=$(get_latest_block_height)
+
+block_difference=$((final_height - initial_height))
+
+if [ "$block_difference" -eq 0 ]; then
+  echo "No blocks ingested. Exiting."
+  exit 1
+fi
+
+blocks_per_second=$(echo "scale=2; $block_difference / 10" | bc)
+blocks_per_minute=$(echo "scale=2; $blocks_per_second * 60" | bc)
+blocks_per_hour=$(echo "scale=2; $blocks_per_minute * 60" | bc)
+
+current_upgrade=$(get_correct_current_upgrade "$final_height")
+next_upgrade=$(get_next_upgrade "$final_height")
+
+current_upgrade_name=$(echo "$current_upgrade" | jq -r '.name')
+current_upgrade_tag=$(echo "$current_upgrade" | jq -r '.tag')
+current_upgrade_height=$(echo "$current_upgrade" | jq -r '.height')
+
+next_upgrade_name=$(echo "$next_upgrade" | jq -r '.name')
+next_upgrade_tag=$(echo "$next_upgrade" | jq -r '.tag')
+next_upgrade_height=$(echo "$next_upgrade" | jq -r '.height')
+
+if [ "$next_upgrade_height" != "null" ]; then
+  blocks_until_next_upgrade=$((next_upgrade_height - final_height))
+
+  if [ "$blocks_until_next_upgrade" -eq 0 ]; then
+    echo "No blocks left until next upgrade. Exiting."
+    exit 0
+  fi
+
+  seconds_until_next_upgrade=$(echo "$blocks_until_next_upgrade / $blocks_per_second" | bc)
+
+  estimated_next_upgrade_unix=$((end_time_unix + seconds_until_next_upgrade))
+  estimated_next_upgrade_time=$(date -d @"$estimated_next_upgrade_unix" +"%Y-%m-%d %H:%M:%S")
+
+  minutes_until_next_upgrade=$(echo "$seconds_until_next_upgrade / 60" | bc)
+else
+  estimated_next_upgrade_time="N/A"
+  minutes_until_next_upgrade="N/A"
+fi
+
+echo "Start block height: $initial_height at $start_time"
+echo "End block height: $final_height at $end_time"
+echo "Blocks ingested per second: $blocks_per_second"
+echo "Blocks ingested per minute: $blocks_per_minute"
+echo "Blocks ingested per hour: $blocks_per_hour"
+echo "Current upgrade: $current_upgrade_name (Tag: $current_upgrade_tag, Height: $current_upgrade_height)"
+if [ "$next_upgrade_height" != "null" ]; then
+  echo "Next upgrade: $next_upgrade_name (Tag: $next_upgrade_tag, Height: $next_upgrade_height)"
+  echo "Blocks left until next upgrade: $blocks_until_next_upgrade"
+  echo "Total minutes until next upgrade: $minutes_until_next_upgrade minutes"
+  echo "Estimated time of next upgrade: $estimated_next_upgrade_time"
+else
+  echo "No upcoming upgrades found."
+fi
+

--- a/archive-node/status_loop.sh
+++ b/archive-node/status_loop.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+SCRIPT_PATH="./status.sh"
+
+while true; do
+  bash $SCRIPT_PATH
+  EXIT_CODE=$?
+
+  if [ $EXIT_CODE -ne 0 ]; then
+    echo "An error occurred or no blocks left until next upgrade. Trying again in 60 seconds"
+    sleep 60
+  fi
+
+  echo "###############"
+
+  sleep 50
+done
+

--- a/archive-node/upgrades.json
+++ b/archive-node/upgrades.json
@@ -1,0 +1,18 @@
+{"upgrades":[
+    { "height": 15727333, "name": "tourmaline", "tag":"v1.18.0"},
+    { "height": 13736000, "name": "saffron", "tag":"v1.17.1"},
+    { "height": 11842000, "name": "rust", "tag":"v1.16.0"},
+    { "height": 11130222, "name": "quicksilver", "tag":"v1.15.2"},
+    { "height": 9828888, "name": "paua", "tag":"v1.14.1"},
+    { "height": 8485555, "name": "ochre", "tag":"v1.13.1"},
+    { "height": 7334444, "name": "neoncarrot", "tag":"v1.12.2"},
+    { "height": 6512577, "name": "mango", "tag":"v1.11.1"},
+    { "height": 5689885, "name": "lava", "tag":"v1.10.0"},
+    { "height": 4808400, "name": "green", "tag":" v1.8.2"},
+    { "height": 2641250, "name": "feldgrau", "tag":" v1.7.6"},
+    { "height": 2000000, "name": "usdf", "tag":" v1.6.0"},
+    { "height": 1442070, "name": "desert", "tag":" v1.5.0"},
+    { "height": 940500, "name": "citrine", "tag":" v1.4.1"},
+    { "height": 352000, "name": "bluetiful", "tag":" v1.3.1"},
+    { "height": 0, "name": "Genesis", "tag":" v1.0.1"}
+]}

--- a/archive-node/upgrades.json
+++ b/archive-node/upgrades.json
@@ -1,4 +1,5 @@
 {"upgrades":[
+    { "height": 17946888, "name": "umber", "tag":"v1.19.1"},
     { "height": 15727333, "name": "tourmaline", "tag":"v1.18.0"},
     { "height": 13736000, "name": "saffron", "tag":"v1.17.1"},
     { "height": 11842000, "name": "rust", "tag":"v1.16.0"},

--- a/archive-node/v1.10.0.sh
+++ b/archive-node/v1.10.0.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -ex
+
+# !!!!!!!!!!!!! Node Sync Processes !!!!!!!!!!!!!!!!!
+
+# if previous step not complete then exit
+if [ ! -f "./v1.8.2-done" ]; then exit 0; fi
+
+# if we are already done here then don't run this file again
+if [ -f "./v1.10.0-done" ]; then exit 0; fi
+
+# look for the proper software binary, if not found then build it.
+if [ ! -f "./software/v1.10.0/provenanced" ]; then
+
+    pushd ./software/source
+    git checkout v1.10.0
+    make clean build
+    mkdir -p ../v1.10.0/
+    cp ./build/* ../v1.10.0
+    popd
+
+fi;
+
+# 5689885      lava             v1.10.0
+./software/v1.10.0/provenanced --home="./node" start --log_level=warn --halt-height=6512525
+rm -rf ./data/wasm/wasm/cache
+tar czf ./archive/6512525-1.10.0.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
+./software/v1.10.0/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+
+touch ./v1.10.0-done

--- a/archive-node/v1.10.0.sh
+++ b/archive-node/v1.10.0.sh
@@ -25,6 +25,6 @@ fi;
 ./software/v1.10.0/provenanced --home="./node" start --log_level=warn --halt-height=6512525
 rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/6512525-1.10.0.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
-./software/v1.10.0/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+./software/v1.10.0/provenanced --home="./node" start --log_level=warn || true  # run until upgrade halts node, don't exit script on upgrade panic
 
 touch ./v1.10.0-done

--- a/archive-node/v1.10.0.sh
+++ b/archive-node/v1.10.0.sh
@@ -23,7 +23,7 @@ fi;
 
 # 5689885      lava             v1.10.0
 ./software/v1.10.0/provenanced --home="./node" start --log_level=warn --halt-height=6512525
-rm -rf ./data/wasm/wasm/cache
+rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/6512525-1.10.0.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
 ./software/v1.10.0/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
 

--- a/archive-node/v1.11.1.sh
+++ b/archive-node/v1.11.1.sh
@@ -23,8 +23,8 @@ fi;
 
 # 6512577      mango            v1.11.1
 ./software/v1.11.1/provenanced --home="./node" start --log_level=warn --halt-height=7334400
-rm -rf ./data/wasm/wasm/cache
+rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/7334400-1.11.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
-./software/v1.11.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+./software/v1.11.1/provenanced --home="./node" start --log_level=warn || true  # run until upgrade halts node, don't exit script on upgrade panic
 
 touch ./v1.11.1-done

--- a/archive-node/v1.11.1.sh
+++ b/archive-node/v1.11.1.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -ex
+
+# !!!!!!!!!!!!! Node Sync Processes !!!!!!!!!!!!!!!!!
+
+# if previous step not complete then exit
+if [ ! -f "./v1.10.0-done" ]; then exit 0; fi
+
+# if we are already done here then don't run this file again
+if [ -f "./v1.11.1-done" ]; then exit 0; fi
+
+# look for the proper software binary, if not found then build it.
+if [ ! -f "./software/v1.11.1/provenanced" ]; then
+
+    pushd ./software/source
+    git checkout v1.11.1
+    make clean build
+    mkdir -p ../v1.11.1/
+    cp ./build/* ../v1.11.1
+    popd
+
+fi;
+
+# 6512577      mango            v1.11.1
+./software/v1.11.1/provenanced --home="./node" start --log_level=warn --halt-height=7334400
+rm -rf ./data/wasm/wasm/cache
+tar czf ./archive/7334400-1.11.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
+./software/v1.11.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+
+touch ./v1.11.1-done

--- a/archive-node/v1.12.2.sh
+++ b/archive-node/v1.12.2.sh
@@ -23,7 +23,7 @@ fi;
 
 # 7334444      neoncarrot       v1.12.2
 ./software/v1.12.2/provenanced --home="./node" start --log_level=warn --halt-height=8485505
-rm -rf ./data/wasm/wasm/cache
+rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/8485505-1.12.2.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
 ./software/v1.12.2/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
 

--- a/archive-node/v1.12.2.sh
+++ b/archive-node/v1.12.2.sh
@@ -25,6 +25,6 @@ fi;
 ./software/v1.12.2/provenanced --home="./node" start --log_level=warn --halt-height=8485505
 rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/8485505-1.12.2.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
-./software/v1.12.2/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+./software/v1.12.2/provenanced --home="./node" start --log_level=warn || true  # run until upgrade halts node, don't exit script on upgrade panic
 
 touch ./v1.12.2-done

--- a/archive-node/v1.12.2.sh
+++ b/archive-node/v1.12.2.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -ex
+
+# !!!!!!!!!!!!! Node Sync Processes !!!!!!!!!!!!!!!!!
+
+# if previous step not complete then exit
+if [ ! -f "./v1.11.1-done" ]; then exit 0; fi
+
+# if we are already done here then don't run this file again
+if [ -f "./v1.12.2-done" ]; then exit 0; fi
+
+# look for the proper software binary, if not found then build it.
+if [ ! -f "./software/v1.12.2/provenanced" ]; then
+
+    pushd ./software/source
+    git checkout v1.12.2
+    make clean build
+    mkdir -p ../v1.12.2/
+    cp ./build/* ../v1.12.2
+    popd
+
+fi;
+
+# 7334444      neoncarrot       v1.12.2
+./software/v1.12.2/provenanced --home="./node" start --log_level=warn --halt-height=8485505
+rm -rf ./data/wasm/wasm/cache
+tar czf ./archive/8485505-1.12.2.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
+./software/v1.12.2/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+
+touch ./v1.12.2-done

--- a/archive-node/v1.13.1.sh
+++ b/archive-node/v1.13.1.sh
@@ -4,7 +4,7 @@ set -ex
 # !!!!!!!!!!!!! Node Sync Processes !!!!!!!!!!!!!!!!!
 
 # if previous step not complete then exit
-if [ !  -f "./v1.12.1-done" ]; then exit 0; fi
+if [ !  -f "./v1.12.2-done" ]; then exit 0; fi
 
 # if we are already done here then don't run this file again
 if [ -f "./v1.13.1-done" ]; then exit 0; fi

--- a/archive-node/v1.13.1.sh
+++ b/archive-node/v1.13.1.sh
@@ -29,7 +29,7 @@ fi;
 # 8485555      ochre            v1.13.1
 ./software/v1.13.1/provenanced --home="./node" start --log_level=warn --halt-height=8485556 # restart now to deal with iavl upgrade
 ./software/v1.13.1/provenanced --home="./node" start --log_level=warn --halt-height=9828880 # run through 1.13.x blocks
-rm -rf ./data/wasm/wasm/cache
+rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/9828880-1.13.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
 ./software/v1.13.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
 

--- a/archive-node/v1.13.1.sh
+++ b/archive-node/v1.13.1.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -ex
+
+# !!!!!!!!!!!!! Node Sync Processes !!!!!!!!!!!!!!!!!
+
+# if previous step not complete then exit
+if [ !  -f "./v1.12.1-done" ]; then exit 0; fi
+
+# if we are already done here then don't run this file again
+if [ -f "./v1.13.1-done" ]; then exit 0; fi
+
+# look for the proper software binary, if not found then build it.
+if [ ! -f "./software/v1.13.1/provenanced" ]; then
+
+    pushd ./software/source
+    git checkout v1.13.1
+    make clean build
+    mkdir -p ../v1.13.1/
+    cp ./build/* ../v1.13.1
+    popd
+
+fi;
+
+# Transistion away from cleveldb with this upgrade, ensure that the IAVL fast-sync is enabled
+./software/v1.13.1/provenanced --home="./node" config set db_backend goleveldb
+./software/v1.13.1/provenanced --home="./node" config set iavl-disable-fastnode false
+
+
+# 8485555      ochre            v1.13.1
+./software/v1.13.1/provenanced --home="./node" start --log_level=warn --halt-height=8485556 # restart now to deal with iavl upgrade
+./software/v1.13.1/provenanced --home="./node" start --log_level=warn --halt-height=9828880 # run through 1.13.x blocks
+rm -rf ./data/wasm/wasm/cache
+tar czf ./archive/9828880-1.13.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
+./software/v1.13.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+
+touch ./v1.13.1-done

--- a/archive-node/v1.13.1.sh
+++ b/archive-node/v1.13.1.sh
@@ -31,6 +31,6 @@ fi;
 ./software/v1.13.1/provenanced --home="./node" start --log_level=warn --halt-height=9828880 # run through 1.13.x blocks
 rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/9828880-1.13.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
-./software/v1.13.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+./software/v1.13.1/provenanced --home="./node" start --log_level=warn || true  # run until upgrade halts node, don't exit script on upgrade panic
 
 touch ./v1.13.1-done

--- a/archive-node/v1.14.1.sh
+++ b/archive-node/v1.14.1.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -ex
+
+# !!!!!!!!!!!!! Node Sync Processes !!!!!!!!!!!!!!!!!
+
+# if previous step not complete then exit
+if [ ! -f "./v1.13.1-done" ]; then exit 0; fi
+
+# if we are already done here then don't run this file again
+if [ -f "./v1.14.1-done" ]; then exit 0; fi
+
+# look for the proper software binary, if not found then build it.
+if [ ! -f "./software/v1.14.1/provenanced" ]; then
+
+    pushd ./software/source
+    git checkout v1.14.1
+    make clean build
+    mkdir -p ../v1.14.1/
+    cp ./build/* ../v1.14.1
+    popd
+
+fi;
+
+# 9828888      paua             v1.14.1
+./software/v1.14.1/provenanced --home="./node" start --log_level=warn --halt-height=11130200
+rm -rf ./data/wasm/wasm/cache
+tar czf ./archive/11130200-1.14.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
+./software/v1.14.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+
+touch ./v1.14.1-done

--- a/archive-node/v1.14.1.sh
+++ b/archive-node/v1.14.1.sh
@@ -25,6 +25,6 @@ fi;
 ./software/v1.14.1/provenanced --home="./node" start --log_level=warn --halt-height=11130200
 rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/11130200-1.14.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
-./software/v1.14.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+./software/v1.14.1/provenanced --home="./node" start --log_level=warn || true  # run until upgrade halts node, don't exit script on upgrade panic
 
 touch ./v1.14.1-done

--- a/archive-node/v1.14.1.sh
+++ b/archive-node/v1.14.1.sh
@@ -23,7 +23,7 @@ fi;
 
 # 9828888      paua             v1.14.1
 ./software/v1.14.1/provenanced --home="./node" start --log_level=warn --halt-height=11130200
-rm -rf ./data/wasm/wasm/cache
+rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/11130200-1.14.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
 ./software/v1.14.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
 

--- a/archive-node/v1.15.2.sh
+++ b/archive-node/v1.15.2.sh
@@ -24,7 +24,7 @@ fi;
 
 # 11130222     quicksilver      v1.15.2
 ./software/v1.15.2/provenanced --home="./node" start --log_level=warn --halt-height=11841950
-rm -rf ./data/wasm/wasm/cache
+rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/11841950-1.15.2.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
 ./software/v1.15.2/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
 

--- a/archive-node/v1.15.2.sh
+++ b/archive-node/v1.15.2.sh
@@ -26,6 +26,6 @@ fi;
 ./software/v1.15.2/provenanced --home="./node" start --log_level=warn --halt-height=11841950
 rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/11841950-1.15.2.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
-./software/v1.15.2/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+./software/v1.15.2/provenanced --home="./node" start --log_level=warn || true  # run until upgrade halts node, don't exit script on upgrade panic
 
 touch ./v1.15.2-done

--- a/archive-node/v1.15.2.sh
+++ b/archive-node/v1.15.2.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -ex
+
+# !!!!!!!!!!!!! Node Sync Processes !!!!!!!!!!!!!!!!!
+
+# if previous step not complete then exit
+if [ ! -f "./v1.14.1-done" ]; then exit 0; fi
+
+# if we are already done here then don't run this file again
+if [ -f "./v1.15.2-done" ]; then exit 0; fi
+
+# look for the proper software binary, if not found then build it.
+if [ ! -f "./software/v1.15.2/provenanced" ]; then
+
+    pushd ./software/source
+    git checkout v1.15.2
+    make clean build
+    mkdir -p ../v1.15.2/
+    cp ./build/* ../v1.15.2
+    popd
+
+fi;
+
+
+# 11130222     quicksilver      v1.15.2
+./software/v1.15.2/provenanced --home="./node" start --log_level=warn --halt-height=11841950
+rm -rf ./data/wasm/wasm/cache
+tar czf ./archive/11841950-1.15.2.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
+./software/v1.15.2/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+
+touch ./v1.15.2-done

--- a/archive-node/v1.16.0.sh
+++ b/archive-node/v1.16.0.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -ex
+
+# !!!!!!!!!!!!! Node Sync Processes !!!!!!!!!!!!!!!!!
+
+# if previous step not complete then exit
+if [ ! -f "./v1.15.2-done" ]; then exit 0; fi
+
+# if we are already done here then don't run this file again
+if [ -f "./v1.16.0-done" ]; then exit 0; fi
+
+# look for the proper software binary, if not found then build it.
+if [ ! -f "./software/v1.16.0/provenanced" ]; then
+
+    pushd ./software/source
+    git checkout v1.16.0
+    make clean build
+    mkdir -p ../v1.16.0/
+    cp ./build/* ../v1.16.0
+    popd
+
+fi;
+
+# 11842000     rust             v1.16.0
+./software/v1.16.0/provenanced pre-upgrade --home="./node"
+./software/v1.16.0/provenanced --home="./node" start --log_level=warn --halt-height=13735950
+rm -rf ./data/wasm/wasm/cache
+tar czf ./archive/13735950-1.16.0.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
+./software/v1.16.0/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+
+touch ./v1.16.0-done

--- a/archive-node/v1.16.0.sh
+++ b/archive-node/v1.16.0.sh
@@ -26,6 +26,6 @@ fi;
 ./software/v1.16.0/provenanced --home="./node" start --log_level=warn --halt-height=13735950
 rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/13735950-1.16.0.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
-./software/v1.16.0/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+./software/v1.16.0/provenanced --home="./node" start --log_level=warn || true  # run until upgrade halts node, don't exit script on upgrade panic
 
 touch ./v1.16.0-done

--- a/archive-node/v1.16.0.sh
+++ b/archive-node/v1.16.0.sh
@@ -24,7 +24,7 @@ fi;
 # 11842000     rust             v1.16.0
 ./software/v1.16.0/provenanced pre-upgrade --home="./node"
 ./software/v1.16.0/provenanced --home="./node" start --log_level=warn --halt-height=13735950
-rm -rf ./data/wasm/wasm/cache
+rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/13735950-1.16.0.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
 ./software/v1.16.0/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
 

--- a/archive-node/v1.17.1.sh
+++ b/archive-node/v1.17.1.sh
@@ -24,7 +24,7 @@ fi;
 # 13736000     saffron          v1.17.1
 ./software/v1.17.1/provenanced pre-upgrade --home="./node"
 ./software/v1.17.1/provenanced --home="./node" start --log_level=warn --halt-height=15727300
-rm -rf ./data/wasm/wasm/cache
+rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/15727300-1.17.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
 ./software/v1.17.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
 

--- a/archive-node/v1.17.1.sh
+++ b/archive-node/v1.17.1.sh
@@ -26,6 +26,6 @@ fi;
 ./software/v1.17.1/provenanced --home="./node" start --log_level=warn --halt-height=15727300
 rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/15727300-1.17.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
-./software/v1.17.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+./software/v1.17.1/provenanced --home="./node" start --log_level=warn || true  # run until upgrade halts node, don't exit script on upgrade panic
 
 touch ./v1.17.1-done

--- a/archive-node/v1.17.1.sh
+++ b/archive-node/v1.17.1.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -ex
+
+# !!!!!!!!!!!!! Node Sync Processes !!!!!!!!!!!!!!!!!
+
+# if previous step not complete then exit
+if [ ! -f "./v1.16.0-done" ]; then exit 0; fi
+
+# if we are already done here then don't run this file again
+if [ -f "./v1.17.1-done" ]; then exit 0; fi
+
+# look for the proper software binary, if not found then build it.
+if [ ! -f "./software/v1.17.1/provenanced" ]; then
+
+    pushd ./software/source
+    git checkout v1.17.1
+    make clean build
+    mkdir -p ../v1.17.1/
+    cp ./build/* ../v1.17.1
+    popd
+
+fi;
+
+# 13736000     saffron          v1.17.1
+./software/v1.17.1/provenanced pre-upgrade --home="./node"
+./software/v1.17.1/provenanced --home="./node" start --log_level=warn --halt-height=15727300
+rm -rf ./data/wasm/wasm/cache
+tar czf ./archive/15727300-1.17.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
+./software/v1.17.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+
+touch ./v1.17.1-done

--- a/archive-node/v1.18.0.sh
+++ b/archive-node/v1.18.0.sh
@@ -23,7 +23,9 @@ fi;
 
 # 15727333     tourmaline       v1.18.0
 ./software/v1.18.0/provenanced pre-upgrade --home="./node"
-./software/v1.18.0/provenanced --home="./node" start --log_level=warn
+./software/v1.18.0/provenanced --home="./node" start --log_level=warn --halt-height=17946780
 
-# we are not done with 1.18 yet so this isn't applicable.
-#touch ./v1.18.0-done
+tar czf ./archive/17946780-1.18.0.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
+./software/v1.17.1/provenanced --home="./node" start --log_level=warn || true  # run until upgrade halts node, don't exit script on upgrade panic
+
+touch ./v1.18.0-done

--- a/archive-node/v1.18.0.sh
+++ b/archive-node/v1.18.0.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -ex
+
+# !!!!!!!!!!!!! Node Sync Processes !!!!!!!!!!!!!!!!!
+
+# if previous step not complete then exit
+if [ ! -f "./v1.17.1-done" ]; then exit 0; fi
+
+# if we are already done here then don't run this file again
+if [ -f "./v1.18.0-done" ]; then exit 0; fi
+
+# look for the proper software binary, if not found then build it.
+if [ ! -f "./software/v1.18.0/provenanced" ]; then
+
+    pushd ./software/source
+    git checkout v1.18.0
+    make clean build
+    mkdir -p ../v1.18.0/
+    cp ./build/* ../v1.18.0
+    popd
+
+fi;
+
+# 15727333     tourmaline       v1.18.0
+./software/v1.18.0/provenanced pre-upgrade --home="./node"
+./software/v1.18.0/provenanced --home="./node" start --log_level=warn
+
+# we are not done with 1.18 yet so this isn't applicable.
+#touch ./v1.18.0-done

--- a/archive-node/v1.3.1.sh
+++ b/archive-node/v1.3.1.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -ex
+
+# !!!!!!!!!!!!! Node Sync Processes !!!!!!!!!!!!!!!!!
+
+# if previous step not complete then exit
+if [ ! -f "./v1.0.1-done" ]; then exit 0; fi
+
+# if we are already done here then don't run this file again
+if [ -f "./v1.3.1-done" ]; then exit 0; fi
+
+# look for the proper software binary, if not found then build it.
+if [ ! -f "./software/v1.3.1/provenanced" ]; then
+
+    pushd ./software/source
+    git checkout v1.3.1
+    make clean build
+    mkdir -p ../v1.3.1/
+    cp ./build/* ../v1.3.1
+    popd
+
+fi;
+
+
+# 352000       bluetiful        v1.3.1
+./software/v1.3.1/provenanced --home="./node" start --halt-height=940450 --log_level=warn
+rm -rf ./data/wasm/wasm/cache
+tar czf ./archive/940450-1.3.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
+./software/v1.3.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+
+touch ./v1.3.1-done

--- a/archive-node/v1.3.1.sh
+++ b/archive-node/v1.3.1.sh
@@ -24,7 +24,7 @@ fi;
 
 # 352000       bluetiful        v1.3.1
 ./software/v1.3.1/provenanced --home="./node" start --halt-height=940450 --log_level=warn
-rm -rf ./data/wasm/wasm/cache
+rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/940450-1.3.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
 ./software/v1.3.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
 

--- a/archive-node/v1.3.1.sh
+++ b/archive-node/v1.3.1.sh
@@ -26,6 +26,7 @@ fi;
 ./software/v1.3.1/provenanced --home="./node" start --halt-height=940450 --log_level=warn
 rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/940450-1.3.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
-./software/v1.3.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+
+./software/v1.3.1/provenanced --home="./node" start --log_level=warn || true  # run until upgrade halts node, don't exit script on upgrade panic
 
 touch ./v1.3.1-done

--- a/archive-node/v1.4.1.sh
+++ b/archive-node/v1.4.1.sh
@@ -27,6 +27,6 @@ fi;
 ./software/v1.4.1/provenanced --home="./node" start --halt-height=1442000 --log_level=warn
 rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/1442000-1.4.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
-./software/v1.4.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+./software/v1.4.1/provenanced --home="./node" start --log_level=warn || true  # run until upgrade halts node, don't exit script on upgrade panic
 
 touch ./v1.4.1-done

--- a/archive-node/v1.4.1.sh
+++ b/archive-node/v1.4.1.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -ex
+
+# !!!!!!!!!!!!! Node Sync Processes !!!!!!!!!!!!!!!!!
+
+# if previous step not complete then exit
+if [ ! -f "./v1.3.1-done" ]; then exit 0; fi
+
+# if we are already done here then don't run this file again
+if [ -f "./v1.4.1-done" ]; then exit 0; fi
+
+
+# look for the proper software binary, if not found then build it.
+if [ ! -f "./software/v1.4.1/provenanced" ]; then
+
+    pushd ./software/source
+    git checkout v1.4.1
+    make clean build
+    mkdir -p ../v1.4.1/
+    cp ./build/* ../v1.4.1
+    popd
+
+fi;
+
+
+# 940500       citrine          v1.4.1
+./software/v1.4.1/provenanced --home="./node" start --halt-height=1442000 --log_level=warn
+rm -rf ./data/wasm/wasm/cache
+tar czf ./archive/1442000-1.4.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
+./software/v1.4.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+
+touch ./v1.4.1-done

--- a/archive-node/v1.4.1.sh
+++ b/archive-node/v1.4.1.sh
@@ -25,7 +25,7 @@ fi;
 
 # 940500       citrine          v1.4.1
 ./software/v1.4.1/provenanced --home="./node" start --halt-height=1442000 --log_level=warn
-rm -rf ./data/wasm/wasm/cache
+rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/1442000-1.4.1.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
 ./software/v1.4.1/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
 

--- a/archive-node/v1.5.0.sh
+++ b/archive-node/v1.5.0.sh
@@ -26,6 +26,6 @@ fi;
 ./software/v1.5.0/provenanced --home="./node" start --log_level=warn --halt-height=1999950
 rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/1999950-1.5.0.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
-./software/v1.5.0/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+./software/v1.5.0/provenanced --home="./node" start --log_level=warn || true  # run until upgrade halts node, don't exit script on upgrade panic
 
 touch ./v1.5.0-done

--- a/archive-node/v1.5.0.sh
+++ b/archive-node/v1.5.0.sh
@@ -24,7 +24,7 @@ fi;
 
 # 1442070      desert           v1.5.0
 ./software/v1.5.0/provenanced --home="./node" start --log_level=warn --halt-height=1999950
-rm -rf ./data/wasm/wasm/cache
+rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/1999950-1.5.0.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
 ./software/v1.5.0/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
 

--- a/archive-node/v1.5.0.sh
+++ b/archive-node/v1.5.0.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -ex
+
+# !!!!!!!!!!!!! Node Sync Processes !!!!!!!!!!!!!!!!!
+
+# if previous step not complete then exit
+if [ ! -f "./v1.4.1-done" ]; then exit 0; fi
+
+# if we are already done here then don't run this file again
+if [ -f "./v1.5.0-done" ]; then exit 0; fi
+
+# look for the proper software binary, if not found then build it.
+if [ ! -f "./software/v1.5.0/provenanced" ]; then
+
+    pushd ./software/source
+    git checkout v1.5.0
+    make clean build
+    mkdir -p ../v1.5.0/
+    cp ./build/* ../v1.5.0
+    popd
+
+fi;
+
+
+# 1442070      desert           v1.5.0
+./software/v1.5.0/provenanced --home="./node" start --log_level=warn --halt-height=1999950
+rm -rf ./data/wasm/wasm/cache
+tar czf ./archive/1999950-1.5.0.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
+./software/v1.5.0/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+
+touch ./v1.5.0-done

--- a/archive-node/v1.6.0.sh
+++ b/archive-node/v1.6.0.sh
@@ -25,6 +25,6 @@ fi;
 ./software/v1.6.0/provenanced --home="./node" start --log_level=warn --halt-height=2641200
 rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/2641200-1.6.0.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
-./software/v1.6.0/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+./software/v1.6.0/provenanced --home="./node" start --log_level=warn || true  # run until upgrade halts node, don't exit script on upgrade panic
 
 touch ./v1.6.0-done

--- a/archive-node/v1.6.0.sh
+++ b/archive-node/v1.6.0.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -ex
+
+# !!!!!!!!!!!!! Node Sync Processes !!!!!!!!!!!!!!!!!
+
+# if previous step not complete then exit
+if [ ! -f "./v1.5.0-done" ]; then exit 0; fi
+
+# if we are already done here then don't run this file again
+if [ -f "./v1.6.0-done" ]; then exit 0; fi
+
+# look for the proper software binary, if not found then build it.
+if [ ! -f "./software/v1.6.0/provenanced" ]; then
+
+    pushd ./software/source
+    git checkout v1.6.0
+    make clean build
+    mkdir -p ../v1.6.0/
+    cp ./build/* ../v1.6.0
+    popd
+
+fi;
+
+# 2000000      usdf.c-hotfix    v1.6.0
+./software/v1.6.0/provenanced --home="./node" start --log_level=warn --halt-height=2641200
+rm -rf ./data/wasm/wasm/cache
+tar czf ./archive/2641200-1.6.0.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
+./software/v1.6.0/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+
+touch ./v1.6.0-done

--- a/archive-node/v1.6.0.sh
+++ b/archive-node/v1.6.0.sh
@@ -23,7 +23,7 @@ fi;
 
 # 2000000      usdf.c-hotfix    v1.6.0
 ./software/v1.6.0/provenanced --home="./node" start --log_level=warn --halt-height=2641200
-rm -rf ./data/wasm/wasm/cache
+rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/2641200-1.6.0.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
 ./software/v1.6.0/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
 

--- a/archive-node/v1.7.6.sh
+++ b/archive-node/v1.7.6.sh
@@ -25,6 +25,5 @@ fi;
 ./software/v1.7.6/provenanced --home="./node" start --log_level=warn --halt-height=4808390
 rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/4808390-1.7.6.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
-./software/v1.7.6/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
-
+./software/v1.7.6/provenanced --home="./node" start --log_level=warn || true  # run until upgrade halts node, don't exit script on upgrade panic
 touch ./v1.7.6-done

--- a/archive-node/v1.7.6.sh
+++ b/archive-node/v1.7.6.sh
@@ -23,7 +23,7 @@ fi;
 
 # 2641250      feldgrau         v1.7.6
 ./software/v1.7.6/provenanced --home="./node" start --log_level=warn --halt-height=4808390
-rm -rf ./data/wasm/wasm/cache
+rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/4808390-1.7.6.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
 ./software/v1.7.6/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
 

--- a/archive-node/v1.7.6.sh
+++ b/archive-node/v1.7.6.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -ex
+
+# !!!!!!!!!!!!! Node Sync Processes !!!!!!!!!!!!!!!!!
+
+# if previous step not complete then exit
+if [ ! -f "./v1.6.0-done" ]; then exit 0; fi
+
+# if we are already done here then don't run this file again
+if [ -f "./v1.7.6-done" ]; then exit 0; fi
+
+# look for the proper software binary, if not found then build it.
+if [ ! -f "./software/v1.7.6/provenanced" ]; then
+
+    pushd ./software/source
+    git checkout v1.7.6
+    make clean build
+    mkdir -p ../v1.7.6/
+    cp ./build/* ../v1.7.6
+    popd
+
+fi;
+
+# 2641250      feldgrau         v1.7.6
+./software/v1.7.6/provenanced --home="./node" start --log_level=warn --halt-height=4808390
+rm -rf ./data/wasm/wasm/cache
+tar czf ./archive/4808390-1.7.6.tar.gz ./node/config/genesis.json ./node/config/*.toml ./node/data
+./software/v1.7.6/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+
+touch ./v1.7.6-done

--- a/archive-node/v1.8.2.sh
+++ b/archive-node/v1.8.2.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -ex
+
+# !!!!!!!!!!!!! Node Sync Processes !!!!!!!!!!!!!!!!!
+
+# if previous step not complete then exit
+if [ ! -f "./v1.7.6-done" ]; then exit 0; fi
+
+# if we are already done here then don't run this file again
+if [ -f "./v1.8.2-done" ]; then exit 0; fi
+
+# look for the proper software binary, if not found then build it.
+if [ ! -f "./software/v1.8.2/provenanced" ]; then
+
+    pushd ./software/source
+    git checkout v1.8.2
+    make clean build
+    mkdir -p ../v1.8.2/
+    cp ./build/* ../v1.8.2
+    popd
+
+fi;
+
+# 4808400      green            v1.8.2
+./software/v1.8.2/provenanced --home="./node" start --log_level=warn --halt-height=5689850
+rm -rf ./data/wasm/wasm/cache
+tar czf ./archive/5689850-1.8.2.tar.gz  ./node/config/genesis.json ./node/config/*.toml ./node/data
+./software/v1.8.2/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+
+touch ./v1.8.2-done

--- a/archive-node/v1.8.2.sh
+++ b/archive-node/v1.8.2.sh
@@ -23,7 +23,7 @@ fi;
 
 # 4808400      green            v1.8.2
 ./software/v1.8.2/provenanced --home="./node" start --log_level=warn --halt-height=5689850
-rm -rf ./data/wasm/wasm/cache
+rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/5689850-1.8.2.tar.gz  ./node/config/genesis.json ./node/config/*.toml ./node/data
 ./software/v1.8.2/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
 

--- a/archive-node/v1.8.2.sh
+++ b/archive-node/v1.8.2.sh
@@ -25,6 +25,6 @@ fi;
 ./software/v1.8.2/provenanced --home="./node" start --log_level=warn --halt-height=5689850
 rm -rf ./node/data/wasm/wasm/cache
 tar czf ./archive/5689850-1.8.2.tar.gz  ./node/config/genesis.json ./node/config/*.toml ./node/data
-./software/v1.8.2/provenanced --home="./node" start --log_level=warn # run until upgrade halts node
+./software/v1.8.2/provenanced --home="./node" start --log_level=warn || true  # run until upgrade halts node, don't exit script on upgrade panic
 
 touch ./v1.8.2-done


### PR DESCRIPTION
This is a set of basic scripts for creating an archive node that is synced from genesis.  A conscious  choice was made to use separate and simple scripts for each version so that any associated changes associated with that upgrade can be included (such as switching database backends from cleveldb to goleveldb.

This process is a useful solution for #24 as we have noticed that many users that need an archive node prefer to create their instance directly and not rely on snapshots created by others for integrity and security reasons.